### PR TITLE
Add candidate paths + improve GMA memory usage

### DIFF
--- a/gif/Form1.cs
+++ b/gif/Form1.cs
@@ -140,19 +140,13 @@ namespace gif
 
                 try
                 {
-                    bool firstOccurance = false;
                     IEnumerable<string> lines = File.ReadLines(file);
                     foreach (string line in lines)
                     {
                         if (line.Contains("I hope you realize you aren't safe in workshop anymore"))
-                            firstOccurance = true;
-                    }
-
-                    if (firstOccurance)
-                    {
-                        if (lstInfectedFiles.InvokeRequired)
                         {
                             lstInfectedFiles.Invoke(new MethodInvoker(delegate { lstInfectedFiles.Items.Add(file); }));
+                            break;
                         }
                     }
                 }

--- a/gif/Form1.cs
+++ b/gif/Form1.cs
@@ -33,7 +33,9 @@ namespace gif
             {
                 @"Program Files\Steam",
                 @"Program Files (x86)\Steam",
-                @"Steam\steamapps\common\GarrysMod\garrysmod\addons"
+                @"Steam\steamapps\common\GarrysMod\garrysmod\addons",
+                @"Steam\steamapps\workshop\content\4000",
+                @"SteamLibrary\steamapps\workshop\content\4000"
             };
 
             foreach (var drive in DriveInfo.GetDrives())
@@ -94,6 +96,11 @@ namespace gif
                 displayError($"Directory \"{txtboxFilePath.Text}\" is not a valid directory", "Folder directory/path error");
                 return;
             }
+            catch (IOException ioEx)
+            {
+                displayError($"There was an error trying get the files from the directory\nError: {ioEx.Message}", "File retrieval/access error");
+                return;
+            }
             catch (Exception genEx)
             {
                 displayError($"There was an error using this program\nError: {genEx.Message}", "General program error");
@@ -131,15 +138,33 @@ namespace gif
                     progressBar.Invoke(new MethodInvoker(delegate { progressBar.Value += 1; }));
                 }
 
-                string[] lines = File.ReadAllLines(file);
-                string? firstOccurance = lines.FirstOrDefault(line => line.Contains("I hope you realize you aren't safe in workshop anymore"));
-
-                if (firstOccurance != null)
+                try
                 {
-                    if (lstInfectedFiles.InvokeRequired)
+                    bool firstOccurance = false;
+                    IEnumerable<string> lines = File.ReadLines(file);
+                    foreach (string line in lines)
                     {
-                        lstInfectedFiles.Invoke(new MethodInvoker(delegate { lstInfectedFiles.Items.Add(file); }));
+                        if (line.Contains("I hope you realize you aren't safe in workshop anymore"))
+                            firstOccurance = true;
                     }
+
+                    if (firstOccurance)
+                    {
+                        if (lstInfectedFiles.InvokeRequired)
+                        {
+                            lstInfectedFiles.Invoke(new MethodInvoker(delegate { lstInfectedFiles.Items.Add(file); }));
+                        }
+                    }
+                }
+                catch (IOException ioEx)
+                {
+                    displayError($"There was an error trying read the .gma files\nError: {ioEx.Message}", "File read error");
+                    return;
+                }
+                catch (Exception genEx)
+                {
+                    displayError($"There was an error trying to use the program\nError: {genEx.Message}", "General program error");
+                    return;
                 }
             }
 


### PR DESCRIPTION
Added 2 potential paths for Garry's Mod addons being located and now the program will use a different way to read GMA files. From testing below.


Before scan (Old code):
![image](https://user-images.githubusercontent.com/42122270/177014705-c79c4ef2-67f0-4ad7-9e7d-efee14b2ba28.png)

After scan (Old code):
![image](https://user-images.githubusercontent.com/42122270/177014785-ac5ce77b-d8e8-4741-9260-9e4e1d65c828.png)


Before scan (New code):
![image](https://user-images.githubusercontent.com/42122270/177014740-7b73c3bd-18f2-45cf-89d9-6dbed5583756.png)

After scan (New code):
![image](https://user-images.githubusercontent.com/42122270/177014766-b88820b5-996c-493e-9b55-7ace2f68f249.png)